### PR TITLE
[FIX] sentry: event dropped if include_context key not present

### DIFF
--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -63,7 +63,7 @@ def before_send(event, hint):
         if logger_name and not logging.getLogger(logger_name).propagate:
             return None
 
-    if event.setdefault("tags", {})["include_context"]:
+    if event.setdefault("tags", {}).get("include_context"):
         cxtest = get_extra_context(odoo.http.request)
         info_request = ["tags", "user", "extra", "request"]
 

--- a/sentry/tests/test_client.py
+++ b/sentry/tests/test_client.py
@@ -14,7 +14,7 @@ from odoo.tests import TransactionCase
 from odoo.tools import config, mute_logger
 
 from ..const import to_int_if_defined
-from ..hooks import initialize_sentry
+from ..hooks import before_send, initialize_sentry
 
 GIT_SHA = "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
 RELEASE = "test@1.2.3"
@@ -50,7 +50,7 @@ class InMemoryTransport(HttpTransport):
                 event.get_event().get("level") == event_level
                 and event.get_event().get("logentry", {}).get("message") == event_msg
             ):
-                return True
+                return event.get_event()
         return False
 
     def flush(self, *args, **kwargs):
@@ -159,6 +159,22 @@ class TestClientSetup(TransactionCase):
         self.log(level, msg, exc_info)
         level = "error"
         self.assertEventCaptured(self.client, level, msg)
+
+    def test_capture_events_no_tags(self):
+        """Our 'before_send' can handle events without tags"""
+        level, msg = logging.ERROR, "Test event, can be ignored exception"
+        try:
+            raise TestException(msg)
+        except TestException:
+            exc_info = sys.exc_info()
+        self.log(level, msg, exc_info)
+        level = "error"
+        event = self.client.transport.has_event(level, msg)
+        self.assertTrue(event)
+        # Offer an event without tags to the before_send hook
+        if "tags" in event:
+            del event["tags"]
+        self.assertTrue(before_send(event, {}))
 
     def test_ignore_exceptions(self):
         self.patch_config(


### PR DESCRIPTION
Fixes

```
  File "/home/odoo/.local/lib/python3.12/site-packages/sentry_sdk/client.py", line 595, in _prepare_event
    new_event = before_send(event, hint or {})
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/oca-server-tools/sentry/hooks.py", line 66, in before_send
    if event.setdefault("tags", {})["include_context"]:
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'include_context'
2025-07-08 14:45:45,907 14296 INFO quatra-18-0-development-21441249 sentry_sdk.errors: before send dropped event
```

Error is only logged when running Sentry in debug mode, otherwise events are dropped silently.